### PR TITLE
Updated gitignore to ignore jacoco directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ nbbuild/
 dist/
 nbdist/
 .nb-gradle/
+
+# Jacoco
+.jacocoverage/


### PR DESCRIPTION
This is just a small change to tell git to ignore files in the .jacocoverage directory. These files are created when you run a code coverage test on your local repository.