### PR TITLE
Feed title, remove feed selector, UI layout tweaks (fixes #24 fixes #25)

### DIFF
--- a/RSSReader/src/app/RSS_GUI.fxml
+++ b/RSSReader/src/app/RSS_GUI.fxml
@@ -7,7 +7,7 @@
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane id="AnchorPane" fx:id="root" prefHeight="537.0" prefWidth="947.0" xmlns="http://javafx.com/javafx/9" xmlns:fx="http://javafx.com/fxml/1" fx:controller="app.FXMLDocumentController">
+<AnchorPane id="AnchorPane" fx:id="root" prefHeight="537.0" prefWidth="947.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="app.FXMLDocumentController">
    <children>
       <TextArea editable="false" layoutX="35.0" layoutY="323.0" prefHeight="200.0" prefWidth="862.0" AnchorPane.bottomAnchor="35.0" AnchorPane.leftAnchor="35.0" AnchorPane.rightAnchor="35.0" AnchorPane.topAnchor="323.0" />
     <AnchorPane layoutX="278.0" layoutY="253.0" minHeight="0.0" minWidth="0.0" prefHeight="200.0" prefWidth="200.0" />

--- a/RSSReader/src/app/RSS_GUI.fxml
+++ b/RSSReader/src/app/RSS_GUI.fxml
@@ -1,33 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import java.lang.*?>
-<?import java.util.*?>
-<?import javafx.scene.*?>
-<?import javafx.scene.control.*?>
-<?import javafx.scene.layout.*?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.TableColumn?>
+<?import javafx.scene.control.TableView?>
+<?import javafx.scene.control.TextArea?>
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.text.Font?>
 
-<AnchorPane id="AnchorPane" fx:id="root" prefHeight="537.0" prefWidth="947.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="app.FXMLDocumentController">
+<AnchorPane id="AnchorPane" fx:id="root" prefHeight="537.0" prefWidth="947.0" xmlns="http://javafx.com/javafx/9" xmlns:fx="http://javafx.com/fxml/1" fx:controller="app.FXMLDocumentController">
    <children>
+      <TextArea editable="false" layoutX="35.0" layoutY="323.0" prefHeight="200.0" prefWidth="862.0" AnchorPane.bottomAnchor="35.0" AnchorPane.leftAnchor="35.0" AnchorPane.rightAnchor="35.0" AnchorPane.topAnchor="323.0" />
     <AnchorPane layoutX="278.0" layoutY="253.0" minHeight="0.0" minWidth="0.0" prefHeight="200.0" prefWidth="200.0" />
-      <ScrollPane layoutX="30.0" layoutY="62.0" prefHeight="452.0" prefWidth="137.0">
-         <content>
-            <TextArea prefHeight="452.0" prefWidth="124.0" />
-         </content>
-      </ScrollPane>
-      <TableView fx:id="rssTable" layoutX="186.0" layoutY="62.0" prefHeight="241.0" prefWidth="725.0">
+      <TableView fx:id="rssTable" layoutX="186.0" layoutY="62.0" prefHeight="241.0" AnchorPane.leftAnchor="35.0" AnchorPane.rightAnchor="35.0" AnchorPane.topAnchor="60.0">
         <columns>
           <TableColumn fx:id="titleCol" editable="false" prefWidth="75.0" text="Title" />
             <TableColumn fx:id="descriptCol" editable="false" prefWidth="111.0" text="Description" />
             <TableColumn fx:id="dateCol" editable="false" prefWidth="78.0" text="Date" />
           <TableColumn fx:id="linkCol" editable="false" prefWidth="75.0" text="Link" />
         </columns>
+         <columnResizePolicy>
+            <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
+         </columnResizePolicy>
       </TableView>
-      <ScrollPane layoutX="187.0" layoutY="314.0" prefHeight="200.0" prefWidth="725.0">
-         <content>
-            <TextArea prefHeight="200.0" prefWidth="737.0" />
-         </content>
-      </ScrollPane>
-      <TextField alignment="CENTER" layoutX="395.0" layoutY="24.0" promptText="lbl_title" text="RSS Reader" />
-      <TextField alignment="CENTER" layoutX="30.0" layoutY="24.0" prefHeight="27.0" prefWidth="137.0" promptText="lbl_feed" text="Feed" />
+      <Label alignment="CENTER" contentDisplay="CENTER" focusTraversable="false" layoutX="361.0" layoutY="22.0" text="ITS Alerts RSS Feed" textAlignment="CENTER" AnchorPane.leftAnchor="35.0" AnchorPane.rightAnchor="35.0" AnchorPane.topAnchor="22.0">
+         <font>
+            <Font name="System Bold" size="13.0" />
+         </font>
+      </Label>
    </children>
 </AnchorPane>


### PR DESCRIPTION
I updated the UI as specified in #24 and #25. I also made some tweaks to anchors and found the tableview property that makes it space columns nicely.

This shouldn't have any effect on #23.

<img width="1059" alt="screen shot 2018-02-10 at 5 03 08 pm" src="https://user-images.githubusercontent.com/32883148/36068194-5ce4d2e2-0e84-11e8-9e9c-39c2d7869633.png">
